### PR TITLE
Adding atou64 and utoa64

### DIFF
--- a/include/siot-string.h
+++ b/include/siot-string.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 #ifndef __SIOT_STRING_H__
 #define __SIOT_STRING_H__
 
@@ -5,5 +7,7 @@ void ftoa(float num, char *str, int precision);
 char *itoa(int num, char *str, int base);
 int atoi(const char *str);
 float atof(const char *str);
+char *utoa64(uint64_t num, char *str, int base);
+uint64_t atou64(const char *str);
 
 #endif // __SIOT_STRING__

--- a/lib/siot-string.c
+++ b/lib/siot-string.c
@@ -1,4 +1,7 @@
 #include <siot-string.h>
+#include <stdint.h>
+#include <zephyr/kernel.h>
+#include <string.h>
 
 void ftoa(float num, char *str, int precision)
 {
@@ -119,6 +122,33 @@ char *itoa(int num, char *str, int base)
 	return str;
 }
 
+char *utoa64(uint64_t num, char *str, int base)
+{
+
+	int i = 0;
+
+	// Handle 0 explicitly
+	if (num == 0) {
+		str[i++] = '0';
+		str[i] = '\0';
+		return str;
+	}
+
+	// Process individual digits
+	while (num != 0) {
+		int rem = num % base;
+		str[i++] = (rem > 9) ? (rem - 10) + 'a' : rem + '0';
+		num = num / base;
+	}
+
+	str[i] = '\0';
+
+	// Reverse the string
+	reverse(str, i);
+
+	return str;
+}
+
 int atoi(const char *str)
 {
 	int result = 0;
@@ -179,4 +209,27 @@ float atof(const char *str)
 	}
 
 	return sign * result;
+}
+
+uint64_t atou64(const char *str)
+{
+	uint64_t result = 0;
+	int i = 0;
+
+	// Handle negative numbers
+	if (str[0] == '-') {
+		return 0;
+	}
+
+	// Convert each digit
+	while (str[i] != '\0') {
+		if (str[i] >= '0' && str[i] <= '9') {
+			result = result * 10 + (str[i] - '0');
+		} else {
+			break; // Stop at non-digit character
+		}
+		i++;
+	}
+
+	return result;
 }

--- a/lib/siot-string.c
+++ b/lib/siot-string.c
@@ -1,7 +1,5 @@
 #include <siot-string.h>
 #include <stdint.h>
-#include <zephyr/kernel.h>
-#include <string.h>
 
 void ftoa(float num, char *str, int precision)
 {


### PR DESCRIPTION
These functions support the point-based data model where timestamps are stored as uint64_t (nanoseconds since Unix epoch). The existing itoa()/atoi() functions only handle 32-bit integers, which cannot represent these large timestamp values. These new functions enable proper serialization/deserialization of 64-bit timestamps to/from JSON or other string formats.